### PR TITLE
Pluggable + Add checks for staging openQA builds

### DIFF
--- a/Bot/BasicBot/Pluggable/Module/OpenQA.pm
+++ b/Bot/BasicBot/Pluggable/Module/OpenQA.pm
@@ -6,7 +6,7 @@ use strict;
 use warnings;
 
 use Mojo::UserAgent;
-use Carp qw(croak);
+use Carp qw(confess carp croak);
 
 
 =pod
@@ -20,9 +20,7 @@ https://metacpan.org/pod/Bot::BasicBot::Pluggable::Module::Shutdown
 https://metacpan.org/pod/Bot::BasicBot::Pluggable::Module::Log
 =cut
 
-
 my $ua = Mojo::UserAgent->new;
-
 
 sub init {
     my ($self) = @_;
@@ -34,14 +32,115 @@ sub init {
     $self->{tick_count} = 0;
 }
 
+my $last_staging_failing_modules = "";
+my $last_staging_modules = "";
+my $do_not_inform_count = 0;
+my $defcon_level = 5;  # chattiness, 5 is lowest level, 1 is really annoying
+
+my %short_links;
+
+sub _gather_error_details {
+    my ($self, $ua, $openqa_failed) = @_;
+    my $host = $self->get('host');
+
+    # try to find out test details if we can
+    # TODO for now we just search for the first error, maybe they are all the
+    # same anyway
+    my $failed_detail = $ua->get($openqa_failed->first->{href})->res->dom->find('span.resborder_fail');
+    return unless $failed_detail;
+    my $failed_detail_url = $failed_detail->first->parent->{href};
+    chomp(my $error_details = $ua->get("$host/$failed_detail_url")->res->dom->find('#content .box pre')->map('text')->join(', '));
+    return $error_details ? ". Details of first error: $error_details" : '';
+}
+
+sub _shorten_url {
+    my ($url) = @_;
+    confess "TODO implement: Only test paths supported right now" unless $url =~ m@tests@;
+    my $short_name = $url =~ s@^.*tests/@t@r;
+    unless ($short_links{$url}) {
+        my $new_tgt = "http://v.gd/$short_name";
+        my $new_tgt_link = $ua->get($new_tgt)->res->dom->at('.biglink');
+        if ($new_tgt_link and $new_tgt_link->{href} eq $url) {
+            # found already existing link not in our in-memory cache
+            $short_links{$url} = $new_tgt;
+        }
+        else {
+            my $my_url = $ua->get("https://v.gd/create.php?format=simple&url=$url&shorturl=$short_name");
+            if ($my_url->res->code != 200) {
+                carp "url shorten failed with code " . $my_url->res->code . ", returning input link instead";
+                return $url;
+            }
+            $short_links{$url} = $my_url->res->text;
+        }
+    }
+    return $short_links{$url};
+}
+
+sub _poll_staging {
+    my ($self) = @_;
+    my $url = $self->get('staging_dashboard');
+    my $openqa_failed = $ua->get($url  => {Accept => '*/*'})->res->dom->find('.openqa-failed');
+    my %openqa_failed_map = ();
+    # group tests by module name to save some space
+    foreach (@$openqa_failed) {
+        push(@{$openqa_failed_map{$_->text}}, _shorten_url($_->{href}));
+        # TODO the test heading could be used to extract the scenario for each
+        # failing test
+        #my $test_heading = $ua->get($_->{href})->res->dom->at('#info_box .panel-heading')->text;
+        #$test_heading =~ s/^.*Build[^-]*-//;
+    };
+    my $failed_str = join ', ', map { $_ . ' (' . join(', ', @{$openqa_failed_map{$_}}) . ')' } keys %openqa_failed_map;
+
+    if ($defcon_level < 5 and !($failed_str eq '')) {
+        $failed_str .= _gather_error_details($self, $ua, $openqa_failed);
+    }
+
+    return $failed_str;
+}
+
+
 sub told {
     my ($self, $mess) = @_;
-    return unless ($mess->{body} =~ /^!/);
+    return unless ($mess->{body} =~ /^!/) or $mess->{address};
     if ($mess->{body} =~ /\bperl\b/) {
         return "I hear Ruby is better than perl..";
     }
     elsif ($mess->{body} =~ /help/) {
         return help();
+    }
+    elsif ($mess->{body} =~ /defcon/) {
+        my $new_defcon = $mess->{body};
+        $new_defcon =~ s/^.*defcon.*([1-5])/$1/g;
+        unless (1 <= $new_defcon && $new_defcon <= 5) {
+            return "Err, I won't accept that. Try a number between 1 and 5, maybe? If you need to ask you are probably NOT ALLOWED to request DEFCON 1";
+        }
+        if ($new_defcon == 1 and not $mess->{who} =~ /$self->get('defcon1_allowed')/) {
+            return "What did I tell you? You are NOT ALLOWED to request DEFCON 1";
+        }
+        my $old_defcon = $defcon_level;
+        $defcon_level = $new_defcon;
+        if ($defcon_level < $old_defcon) {
+            # everytime increase of defcon means probably we are interested in
+            # the status more often so it makes sense to also send out the
+            # next notice in the next tick
+            $do_not_inform_count = 0;
+            return "Heads up everyone, " . $mess->{who} . " requested DEFCON increase from $old_defcon to $defcon_level";
+        }
+        elsif ($defcon_level == $old_defcon) {
+            return $mess->{who} . " <--- stupid, we are already on $old_defcon";
+        }
+        else {
+            return "We are down to $defcon_level, thanks " . $mess->{who};
+        }
+    }
+    elsif ($mess->{body} =~ /status staging/) {
+        my $failed_staging_str = _poll_staging($self);
+        if (length $failed_staging_str > 0) {
+            return "The following staging tests are failing: " . $failed_staging_str;
+        }
+        else {
+            return "Currently there are no failing staging tests, stay sharp!";
+        }
     }
     elsif ($mess->{body} =~ /\blast builds\b/) {
         my $host = $self->get('host');
@@ -61,24 +160,113 @@ sub told {
     #}
 }
 
+sub chanjoin {
+    my ($self, $mess) = @_;
+    return if ($mess->{who} eq $self->bot->{nick});  # TODO check if "nick" is the right attribute of bot
+    if (($defcon_level < 5 and length $last_staging_modules > 0) or ($defcon_level < 3)) {
+        if (length $last_staging_modules > 0) {
+            return "Let me inform you about the current status of staging. The following modules failed: " . _poll_staging($self);
+        }
+        else {
+            return "Hi. There are no failing openQA staging modules right now";
+        }
+    }
+    else {
+        # Don't do anything by default on defcon 5 not to annoy people with
+        # flaky connections
+    }
+}
+
+# how often to inform about current situation in minutes  based on defcon
+my %inform_period_m = (
+     1 => 1,
+     2 => 4,
+     3 => 20,
+     4 => 120,
+     5 => 1440
+ );
+
 sub tick {
     my ($self) = @_;
     croak if scalar @{$self->bot->{channels}} > 1;
-    $self->{tick_count} += 5; # tick is called in 5 second interval
+    my $channel = $self->bot->{channels}->[0];  # we just select the first if multiple
+    # tick is called in 5 second interval
+    # ensuring we always have multiple of the tick period in seconds to make
+    # checks for "... % x == 0" work
+    $self->{tick_count} = ($self->{tick_count} % ~0) + 5;
 
-    if ($self->{tick_count} % ($self->get('notice_period_ready')) == 0) {
-        $self->bot->notice(
-            channel => $self->bot->{channels}->[0],  # we just select the first if multiple
-            body => "openQA bot ready for service, msg me 'help' for details"
-        );
+    return unless ($self->{tick_count} % 60) == 0;  # so far not looking more often than each minute
+    my $failed_staging_str = _poll_staging($self);
+    if ($failed_staging_str eq $last_staging_modules) {
+        $do_not_inform_count++;
+        if ($do_not_inform_count % $inform_period_m{$defcon_level} == 0) {
+            if (length $failed_staging_str > 0) {
+                $self->bot->notice(
+                    channel => $channel,
+                    body => "I just want to remind that the following staging tests are still failing: " . $failed_staging_str,
+                );
+            }
+            else {
+                $self->bot->notice(
+                    channel => $channel,
+                    body => "Everything is still awesome, nothing broken",  # TODO since … last time it broke
+                );
+            }
+        }
     }
+    else {
+        # no failing tests
+        if ($failed_staging_str eq "") {
+            return unless ($defcon_level < 5);  # no report in dc5 necessary, stay quiet
+            $self->bot->notice(
+                channel => $channel,
+                body => "Good news everyone! All staging tests got fixed (or maybe just none completed ...)",
+            );
+        }
+        # state change: no_fail->fail
+        elsif (length $failed_staging_str > length $last_staging_modules and $last_staging_modules eq "") {
+            # same as previously failing
+            # there was no fail in before but now just the same as in before
+            # show up again, see
+            # https://github.com/openSUSE-Team/obs_factory/issues/49
+            if ($failed_staging_str eq $last_staging_failing_modules) {
+                return unless ($defcon_level < 5);
+                $self->bot->notice(
+                    channel => $channel,
+                    body => "Same failing tests as in before: " . $failed_staging_str,
+                );
+            }
+            # different
+            else {
+                $self->bot->notice(
+                    channel => $channel,
+                    body => "There are new failing tests, get to work!: " . $failed_staging_str,
+                );
+            }
+        }
+        # state change: fail->fail_more
+        elsif (length $failed_staging_str > length $last_staging_modules) {
+            $self->bot->notice(
+                channel => $channel,
+                body => "OMG! Even more tests are failing now: " . $failed_staging_str,
+            );
+        }
+        # state change: fail->fail_less
+        else {
+            $self->bot->notice(
+                channel => $channel,
+                body => "Some fixed, but staging tests failed are: " . $failed_staging_str,
+            );
+        }
+        $last_staging_failing_modules = $failed_staging_str;
+    }
+    $last_staging_modules = $failed_staging_str;
 }
 
 # help text for the bot
 sub help { "Help for 'openQA-bot'
     Write a message in a room I am in starting with '!' as a prefix.
-    Try the following commands: perl, last builds"
+    Try the following commands: perl, last builds, status staging, defcon"
 }
 
 1;
-

--- a/README
+++ b/README
@@ -10,23 +10,27 @@ openQA, nothing especially fancy or interesting.
 
 * Install requirements
 
-    cpanm Bot::BasicBot
+    cpanm Bot::BasicBot::Pluggable
     cpanm Mojo::UserAgent
     cpanm POE::Component::SSLify
 
 
 * Call the script
 
-    perl openqa_irc.pl
+    perl openqa_irc
 
 
 * Talk to the bot, e.g. say "!help"
 
 
+* By default the bot starts in "development mode". For a productive instance
+  it is recommended to provide a configuration file, see instructions in
+  `openqa_irc` itself.
+
 
 ## Communication
 
-If you have questions, visit me on irc.freenode.net in #opensuse-factory
+If you have questions, visit me in irc://chat.freenode.net/opensuse-factory
 
 
 ## Contribute

--- a/openqa_irc
+++ b/openqa_irc
@@ -1,0 +1,61 @@
+#!/usr/bin/perl
+use warnings;
+use strict;
+
+use App::Bot::BasicBot::Pluggable;
+
+my $nick = 'openqa-devel';
+my $channel = '#openqa-test';
+
+my $app = App::Bot::BasicBot::Pluggable->new_with_options(
+        server => 'irc.suse.de',
+        port => 6697,
+        channel => [ $channel ], # beware the singular when using pluggable app
+        nick => $nick,
+        module => [ 'Auth', 'Loader', 'OpenQA' ],
+    );
+$app->bot->{ssl} = 1; # cause pluggable app does not forward ssl
+$app->run();
+
+__END__
+
+=head1 NAME
+
+openqa - An openQA bot based on App::Bot::BasicBot::Pluggable
+
+=head1 SYNOPSIS
+
+  openqa_irc --nick openqa --server chat.freenode.net --channel opensuse-factory
+
+=head1 OPTIONS
+
+=over 4
+
+See L<bot-basicbot-pluggable> for details. Additionally supported options: None so far
+
+=head1 CONFIGFILE
+
+Specify I<--configfile> with a path to a YAML configuration file like for
+L<bot-basicbot-pluggable>. The openQA component takes additional arguments.
+If not specified, defaults are used.
+Example for a productive instance:
+
+ server: chat.freenode.net
+ nick: openqa
+ channel:
+  - '#opensuse-factory'
+ settings:
+   OpenQA:
+     host: openqa.opensuse.org
+ store:
+   type: Deep
+   file: openqa.deep
+
+
+=head1 SEE ALSO
+
+L<Bot::BasicBot::Pluggable>
+
+=back
+
+=cut

--- a/openqa_irc
+++ b/openqa_irc
@@ -47,6 +47,7 @@ Example for a productive instance:
  settings:
    OpenQA:
      host: openqa.opensuse.org
+     staging_dashboard: 'https://build.opensuse.org/project/staging_projects/openSUSE:Factory/'
  store:
    type: Deep
    file: openqa.deep

--- a/t/00bootstrap.t
+++ b/t/00bootstrap.t
@@ -1,0 +1,5 @@
+use Test::More;
+
+use_ok('Bot::BasicBot::Pluggable::Module::OpenQA');
+
+done_testing();

--- a/t/01openqa.t
+++ b/t/01openqa.t
@@ -1,0 +1,9 @@
+use Test::More;
+use Test::Bot::BasicBot::Pluggable;
+
+my $bot = Test::Bot::BasicBot::Pluggable->new();
+
+ok(my $ob = $bot->load("OpenQA"), 'load openqa module');
+is($bot->tell_direct("!perl"), "I hear Ruby is better than perl..", "simple messages work");
+
+done_testing();


### PR DESCRIPTION
- Rewrite using Bot::BasicBot::Pluggable
- Group test URLs by module name to save space
- Use v.gd url shortener to shorten URLs
- Try to parse error details in case of 'wait_serial'
- Also react if personally addressed
- Set notice period in tick based on defcon level
- Staging feedback verbosity is based on a DEFCON level
