### PR TITLE
Fix Regex to not allow setting invalid DEFCON

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: perl
 install:
+  - cpanm -nq Devel::Cover::Report::Coveralls
   - cpanm -nq --installdeps --with-feature=coverage .
 script:
-  - make coverage
+  - PERL5OPT=-MDevel::Cover=-coverage,statement,branch,condition,path,subroutine prove -lrsv t
+  - cover
+after_success:
+  - cover -report coveralls

--- a/Bot/BasicBot/Pluggable/Module/OpenQA.pm
+++ b/Bot/BasicBot/Pluggable/Module/OpenQA.pm
@@ -117,7 +117,7 @@ sub told {
     }
     elsif ($mess->{body} =~ /defcon/) {
         my $new_defcon = $mess->{body};
-        $new_defcon =~ s/^.*defcon.*([1-5])/$1/g;
+        $new_defcon =~ s/^.*defcon\s*(\d+)/$1/;
         unless (1 <= $new_defcon && $new_defcon <= 5) {
             return "Err, I won't accept that. Try a number between 1 and 5, maybe? If you need to ask you are probably NOT ALLOWED to request DEFCON 1";
         }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# openqa_irc [![Build Status](https://travis-ci.org/okurz/openqa_irc.svg?branch=master)](https://travis-ci.org/okurz/openqa_irc)
+# openqa_irc [![Build Status](https://travis-ci.org/okurz/openqa_irc.svg?branch=master)](https://travis-ci.org/okurz/openqa_irc) [![Coverage Status](https://coveralls.io/repos/github/okurz/openqa_irc/badge.svg?branch=master)](https://coveralls.io/github/okurz/openqa_irc?branch=master)
 
 IRC bot for openQA in perl
 

--- a/t/01openqa.t
+++ b/t/01openqa.t
@@ -51,5 +51,6 @@ like($bot->tell_direct('defcon 1'), qr/What did I tell you.*/, 'do not allow set
 $bot->{handlers}->{openqa}->set(defcon1_allowed => 'test_user|foo|bar');
 like($bot->tell_direct('defcon 1'), qr/Heads up.*DEFCON increase/, 'set DEFCON works!');
 like($bot->tell_direct('defcon 5'), qr/We are down to/);
+like($bot->tell_direct('defcon 42'), qr/Err, I won't accept that/, 'do not allow setting invalid DEFCON works');
 
 done_testing();


### PR DESCRIPTION
It was still possible to try setting invalid DEFCON
eg 'defcon 42' which resulted in DEFCON 2'

added testcase for scenario mentioned above
